### PR TITLE
RHMAP-8410 install oc tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install -y epel-release && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
+    curl --retry 999 --retry-max-time 0 -sSL https://github.com/openshift/origin/releases/download/v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-linux-64bit.tar.gz | tar xzv && \
+    mv openshift-origin-*/* /usr/bin/ \
     mkdir -p /opt/rhmap/ && \
     sed -i -e 's/Listen 80/Listen 8080/' \
            -e 's|DocumentRoot "/var/www/html"|DocumentRoot "/usr/share/nagios/html"|' \


### PR DESCRIPTION
This adds the OSE client tools which provide oc which will be especially useful for its exec functionality when creating nagios checks with probe into the running pods.
