### PR TITLE
Rhmap 6722 add node core component checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 8080
 ADD sendEmail-epel-7.repo /etc/yum.repos.d/
 
 RUN yum install -y epel-release && \
-    INSTALL_PKGS="httpd nagios telnet supervisor python-jinja2 nagios-plugins-all sendEmail perl-Net-SSLeay perl-IO-Socket-SSL" && \
+    INSTALL_PKGS="httpd nagios telnet supervisor python-jinja2 nagios-plugins-all sendEmail perl-Net-SSLeay perl-IO-Socket-SSL jq" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yum install -y epel-release && \
            -e 's|<Directory "/var/www">|<Directory "/usr/share/nagios/html">|' \
            /etc/httpd/conf/httpd.conf && \
     touch /supervisord.log /supervisord.pid && \
-    mkdir -p /var/log/nagios/archives /var/log/nagios/rw/ /var/log/nagios/spool/checkresults && \
+    mkdir -p /var/log/nagios/archives /var/log/nagios/rw/ /var/log/nagios/spool/checkresults /opt/rhmap/nagios/plugins/ && \
     chmod -R 777 /supervisord.log /supervisord.pid /var/log/nagios \
                  /etc/httpd /etc/passwd /var/log /etc/nagios /usr/lib64/nagios \
                  /var/spool/nagios /run /usr/share/httpd /usr/share/nagios && \
@@ -23,6 +23,8 @@ RUN yum install -y epel-release && \
 
 ADD supervisord.conf /etc/supervisord.conf
 ADD make-nagios-fhservices-cfg make-nagios-commands-cfg fhservices.cfg.j2 commands.cfg.j2 /opt/rhmap/
+ADD plugins/default/* plugins/core/* /opt/rhmap/nagios/plugins/
+RUN chmod -R 755 /opt/rhmap/nagios/plugins/
 ADD start /start
 
 CMD ["/start"]

--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -7,7 +7,7 @@ define command {
 # Check that a component responds to a /sys/info/health over HTTP
 define command {
        command_name   check_fh_component_http_health
-       command_line   $USER1$/check_http -H $ARG1$ -u /sys/info/health -p 8080
+       command_line   /opt/rhmap/nagios/plugins/fh-check-component-health.sh $ARG1$ 8080
 }
 
 define command {

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -4,8 +4,8 @@ import os
 
 from jinja2 import Environment, FileSystemLoader, Template
 
-fh_services_ping = ['fh-messaging', 'fh-metrics']
-fh_services_health = ['fh-messaging', 'fh-metrics']
+fh_services_ping = ['fh-messaging', 'fh-metrics', 'fh-ngui', 'fh-supercore', 'fh-aaa', 'fh-appstore']
+fh_services_health = ['fh-messaging', 'fh-metrics', 'fh-ngui', 'fh-supercore', 'fh-aaa', 'fh-appstore']
 
 rhmap_admin_email = os.getenv('RHMAP_ADMIN_EMAIL', 'root@localhost')
 rhmap_router_dns = os.getenv('RHMAP_ROUTER_DNS', 'rhmap.localhost')

--- a/plugins/default/fh-check-component-health.sh
+++ b/plugins/default/fh-check-component-health.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+######################################################################
+#
+# Nagios Plugin to check the health of a component and associated systems.
+#
+# Author: Peter Braun <pbraun@redhat.com>
+#
+######################################################################
+
+PATH=$PATH:/usr/local/bin
+
+HOST=$1
+PORT=$2
+
+status=0
+
+JSON=$(curl -q http://${HOST}:${PORT}/sys/info/health 2> /dev/null)
+
+#test the JSON is valid
+echo $JSON | jq "." &>/dev/null
+if [ $? -ne 0 ]; then
+  echo "Error parsing JSON:"
+  echo $JSON
+  exit 3
+fi
+
+#Check overall status
+if [ $(echo $JSON | jq -r ".status") != "ok" ]; then
+  echo "Component is not OK ("$(echo $JSON | jq -r ".status")")"
+  echo $JSON | jq -r ".summary"
+  echo $JSON | jq -r '.details[] | select(.test_status != "ok")'
+  status=2
+fi
+
+if [ $status -eq 0 ]; then
+  echo "All systems operating normally."
+fi
+exit $status


### PR DESCRIPTION
* Adds checks for all the core node.js components
* Adds a new nagios module for querying the health endpoint (Copied from an existing check)

Some cross over with https://github.com/feedhenry/nagios-container/pull/5 regarding nagios plugins setup.

Note:

Currently the fh-appstore doesn't have the health endpoint so fails all the time.

