### PR TITLE
Adding tcp check for memcached

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -10,6 +10,12 @@ define command {
        command_line   /opt/rhmap/nagios/plugins/fh-check-component-health.sh $ARG1$ 8080
 }
 
+# Check for valid response from Memcached
+define command {
+       command_name   check_memcached
+       command_line   $USER1$/check_tcp -H memcached -p $ARG1$ -E -s 'version\n' -e 'VERSION' -w2 -c5 -t5
+}
+
 define command {
        command_name   check_nagios_host
        command_line   $USER1$/check_http -H $HOSTADDRESS$ -S
@@ -74,3 +80,13 @@ define service {
        contact_groups rhmapadmins
 }
 {% endfor %}
+
+define service {
+      service_description memcached:ping
+      hosts {{ rhmap_router_dns }}
+      check_command check_memcached!11211
+      use generic-service
+
+      notes This should be able to communicate with memcached on port 11211 and cannot. Check it is running and this server can communicate with it on that port.
+      contact_groups rhmapadmins
+}


### PR DESCRIPTION
As check uses the existing nagios check_tcp plugin, there was no need for additional python plugins. Only change required was a new command and service in the fhservices.cfg.j2 file

@jessesarn @mikenairn @rhcarvalho mind taking a look?