### PR TITLE
Rhmap 8605 use hostgroups for core or mbaas

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -71,7 +71,7 @@ define host {
        use fh-component-container
        address {{ rhmap_router_dns }}
        host_name {{ rhmap_router_dns }}
-       hostgroups core
+       hostgroups {{ rhmap_hostgroups }}
 }
 
 {% for fhservice in fh_services if 'ping' in fhservice['checks'] %}

--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -40,6 +40,16 @@ define contactgroup {
        members            rhmapadmin
 }
 
+define hostgroup {
+       hostgroup_name core
+       alias core
+}
+
+define hostgroup {
+       hostgroup_name mbaas
+       alias mbaas
+}
+
 # Host template
 define host {
   name                    fh-component-container
@@ -61,15 +71,15 @@ define host {
        use fh-component-container
        address {{ rhmap_router_dns }}
        host_name {{ rhmap_router_dns }}
+       hostgroups core
 }
 
 {% for fhservice in fh_services if 'ping' in fhservice['checks'] %}
 define service {
-       service_description {{ fhservice['name']}}::Ping
-       hosts {{ rhmap_router_dns }}
+       service_description {{ fhservice['name'] }}::Ping
        check_command check_fh_component_http_ping!{{ fhservice['name'] }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("ping_endpoint", "/sys/info/ping") }}
        use generic-service
-
+       hostgroup_name {{ ",".join(fhservice['hostgroups']) }}
        notes This server cannot access {{ fhservice['name'] }}, check it is running and that this server is able to talk to it on port 8080
        contact_groups rhmapadmins
 }
@@ -78,10 +88,9 @@ define service {
 {% for fhservice in fh_services if 'health' in fhservice['checks'] %}
 define service {
        service_description {{ fhservice['name'] }}::Health
-       hosts {{ rhmap_router_dns }}
        check_command check_fh_component_health!{{ fhservice['name'] }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("health_endpoint", "/sys/info/health") }}
        use generic-service
-
+       hostgroup_name {{ ",".join(fhservice['hostgroups']) }}
        notes This server failed to get a successful response from the {{ fhservice['name'] }} health endpoint. Check the response code & body and ensure the service and its dependencies are running and configured correctly.
        contact_groups rhmapadmins
 }
@@ -89,20 +98,18 @@ define service {
 
 define service {
       service_description keycloak:Health
-      hosts {{ rhmap_router_dns }}
       check_command check_eap_component_health!ups!8080!/auth/admin!HTTP/1.1 302
       use generic-service
-
+      hostgroup_name core
       notes This server failed to get a successful response from the Keycloak service health endpoint. Check the response code & body and ensure the service and its dependencies are running and configured correctly.
       contact_groups rhmapadmins
 }
 
 define service {
       service_description memcached:ping
-      hosts {{ rhmap_router_dns }}
       check_command check_memcached!11211
       use generic-service
-
+      hostgroup_name core
       notes This should be able to communicate with memcached on port 11211 and cannot. Check it is running and this server can communicate with it on that port.
       contact_groups rhmapadmins
 }

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -17,6 +17,7 @@ fh_services = [
 
 rhmap_admin_email = os.getenv('RHMAP_ADMIN_EMAIL', 'root@localhost')
 rhmap_router_dns = os.getenv('RHMAP_ROUTER_DNS', 'rhmap.localhost')
+rhmap_hostgroups = os.getenv('RHMAP_HOSTGROUPS', 'core')
 
 template_file = '/opt/rhmap/fhservices.cfg.j2'
 nagios_config_filename = '/etc/nagios/conf.d/fhservices.cfg'
@@ -28,6 +29,7 @@ j2env = Environment(loader=FileSystemLoader(template_dirname), trim_blocks=True)
 j2template = j2env.get_template(template_basename)
 
 j2renderedouput = j2template.render(fh_services=fh_services,
+                                    rhmap_hostgroups=rhmap_hostgroups,
                                     rhmap_router_dns=rhmap_router_dns,
                                     rhmap_admin_email=rhmap_admin_email)
 

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -5,14 +5,14 @@ import os
 from jinja2 import Environment, FileSystemLoader, Template
 
 fh_services = [
-    {'name': 'fh-messaging', 'checks': ['ping', 'health']},
-    {'name': 'fh-metrics', 'checks': ['ping', 'health']},
-    {'name': 'fh-ngui', 'checks': ['ping', 'health']},
-    {'name': 'fh-supercore', 'checks': ['ping', 'health']},
-    {'name': 'fh-aaa', 'checks': ['ping', 'health']},
-    {'name': 'fh-appstore', 'checks': ['ping', 'health']},
-    {'name': 'millicore', 'checks': ['health'], 'health_endpoint': '/box/api/health'},
-    {'name': 'ups', 'checks': ['health'], 'health_endpoint': '/ag-push/rest/sys/info/health'}
+    {'name': 'fh-messaging', 'checks': ['ping', 'health'], 'hostgroups': ['core', 'mbaas']},
+    {'name': 'fh-metrics', 'checks': ['ping', 'health'], 'hostgroups': ['core', 'mbaas']},
+    {'name': 'fh-ngui', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'fh-supercore', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'fh-aaa', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'fh-appstore', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'millicore', 'checks': ['health'], 'health_endpoint': '/box/api/health', 'hostgroups': ['core']},
+    {'name': 'ups', 'checks': ['health'], 'health_endpoint': '/ag-push/rest/sys/info/health', 'hostgroups': ['core']}
 ]
 
 rhmap_admin_email = os.getenv('RHMAP_ADMIN_EMAIL', 'root@localhost')


### PR DESCRIPTION
* Allows the nagios image to be shared between both the rhmap core and mbaas.
* Uses an env var to switch between the 2 or both (RHMAP_HOSTGROUPS='core'|'mbaas'|'core,mbaas')
* Uses nagios hostgroups to determine what checks should be applied to what, all services must have a hostgroup_name set on them.

Jira:

https://issues.jboss.org/browse/RHMAP-8605