### PR TITLE
Use flake8 instead of pep8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git
+max-line-length = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - 2.7
 
 install:
-  - pip install pep8
+  - pip install flake8
 
 script:
-  - pep8 plugins/ --show-source
+  - flake8 --show-source
   - python -m unittest discover -s plugins/default

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Run tests:
 
 ```
 python -m unittest discover -s plugins/default
-````
+```
 
 Style Guide:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ More info: https://pypi.python.org/pypi/flake8.
 To format code:
 
 ```
-autopep8 --in-place --aggressive --aggressive plugins/default/**/*.py
+find . -name '*.py' -print0 | xargs -0 autopep8 --in-place --aggressive --aggressive
 ```
 
 More info: https://pypi.python.org/pypi/autopep8.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Nagios server in a Docker container for RHMAP.
 
 ## Development
 
-Install dependencies:
+Install development dependencies:
+
 ```
-pip install pep8
-pip install autopep8
+pip install flake8 autopep8
 ```
 
 Run tests:
@@ -22,13 +22,14 @@ Style Guide:
 
 All python modules should conform to the PEP8 style guide https://www.python.org/dev/peps/pep-0008/
 
-To verify:
+To verify that the code conforms to the style guide, and is free of common
+errors:
 
 ```
-pep8 plugins/ --show-source
+flake8 --show-source
 ```
 
-More info https://pypi.python.org/pypi/pep8
+More info: https://pypi.python.org/pypi/flake8.
 
 To format code:
 
@@ -36,4 +37,6 @@ To format code:
 autopep8 --in-place --aggressive --aggressive plugins/default/**/*.py
 ```
 
-More info https://pypi.python.org/pypi/autopep8
+More info: https://pypi.python.org/pypi/autopep8.
+
+You may integrate `flake8` and `autopep8` with your code editor.

--- a/README.md
+++ b/README.md
@@ -6,37 +6,35 @@ Nagios server in a Docker container for RHMAP.
 
 ## Development
 
-Install development dependencies:
-
-```
-pip install flake8 autopep8
-```
-
-Run tests:
+### Running tests
 
 ```
 python -m unittest discover -s plugins/default
 ```
 
-Style Guide:
+### Style Guide and common problems
 
-All python modules should conform to the PEP8 style guide https://www.python.org/dev/peps/pep-0008/
+We use tools to enforce the [PEP8](https://www.python.org/dev/peps/pep-0008/)
+style guide and prevent common problems on all Python code in this repository.
 
-To verify that the code conforms to the style guide, and is free of common
-errors:
+When developing the project, you'll need to install the dependencies:
+
+```
+pip install flake8 autopep8
+```
+
+Use [flake8](https://pypi.python.org/pypi/flake8) to verify that the code
+conforms to the style guide, and is free of common errors:
 
 ```
 flake8 --show-source
 ```
 
-More info: https://pypi.python.org/pypi/flake8.
-
-To format code:
+Automatically format source code using
+[autopep8](https://pypi.python.org/pypi/autopep8):
 
 ```
 find . -name '*.py' -print0 | xargs -0 autopep8 --in-place --aggressive --aggressive
 ```
-
-More info: https://pypi.python.org/pypi/autopep8.
 
 You may integrate `flake8` and `autopep8` with your code editor.

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import re
 import sys
-import json
 import argparse
 from subprocess import CalledProcessError
 from collections import Counter
@@ -54,7 +53,10 @@ def analize(pod, disks, warning_threshold, critical_threshold):
 
 
 def report(results):
-    unique_statuses = Counter(disk_status for pod, mount, space_usage, inode_usage, disk_status in results)
+    unique_statuses = Counter(
+        disk_status
+        for pod, mount, space_usage, inode_usage, disk_status in results
+    )
 
     ret = max(unique_statuses)
 

--- a/plugins/default/lib/openshift.py
+++ b/plugins/default/lib/openshift.py
@@ -10,8 +10,9 @@ def _get_running_pod_names(oc, project):
     # Manually filter Running pods because of a bug in `oc get`, see:
     # https://github.com/kubernetes/kubernetes/issues/29115
     # return oc("-n", project, "get", "pods", "--show-all=false", "-o", "name")
-    pods = json.loads(oc("-n", project, "get", "pods", "--show-all=false", "-o", "json"))["items"]
-    return [p["metadata"]["name"] for p in pods if p["status"]["phase"] == "Running"]
+    pods = json.loads(oc("-n", project, "get", "pods", "-o", "json"))["items"]
+    return [p["metadata"]["name"]
+            for p in pods if p["status"]["phase"] == "Running"]
 
 
 def get_running_pod_names(project):
@@ -27,6 +28,6 @@ def exec_in_pods(project, pods, cmd):
 
 
 def get_project():
-    with open('/var/run/secrets/kubernetes.io/serviceaccount/namespace', 'r') as nsfile:
-        data = nsfile.read().rstrip("\n")
+    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
+        data = f.read().rstrip("\n")
     return data

--- a/plugins/default/lib/test_disk_usage.py
+++ b/plugins/default/lib/test_disk_usage.py
@@ -42,7 +42,10 @@ class TestParseDfLines(unittest.TestCase):
 
     def runTest(self):
         self.assertEqual(parse_df_lines(
-            "Use% IUse% Mounted on\n  1%    1% /\n 19%    8% /etc/hosts\n  1%    1% /run/secrets/kubernetes.io/serviceaccount"),
+            "Use% IUse% Mounted on\n"
+            "  1%    1% /\n"
+            " 19%    8% /etc/hosts\n"
+            "  1%    1% /run/secrets/kubernetes.io/serviceaccount"),
             [("/", 1, 1), ("/etc/hosts", 19, 8), ("/run/secrets/kubernetes.io/serviceaccount", 1, 1)])
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pep8]
-max-line-length = 160


### PR DESCRIPTION
- Run `flake8` instead of `pep8` on all Python code in the repository
- Suggest auto-formatting all files
- Update README.md