### PR TITLE
Uniform checks

### DIFF
--- a/plugins/default/lib/component_health.py
+++ b/plugins/default/lib/component_health.py
@@ -76,13 +76,9 @@ def report(summary, test_results):
 
 
 def check(host, port, endpoint):
-    try:
-        response = do_request(host, port, endpoint)
-        nagios_status, test_summary, test_results = parse_response(response)
-        report(test_summary, test_results)
-    except RequestError as error:
-        print error.message
-        nagios_status = nagios.CRIT
+    response = do_request(host, port, endpoint)
+    nagios_status, test_summary, test_results = parse_response(response)
+    report(test_summary, test_results)
     return nagios_status
 
 

--- a/plugins/default/lib/component_health.py
+++ b/plugins/default/lib/component_health.py
@@ -7,34 +7,29 @@ import urllib2
 import nagios
 
 
+def generate_parser():
+    parser = argparse.ArgumentParser(
+        description="Checks the health endpoint of an RHMAP component",
+    )
+    parser.add_argument(
+        "-H", "--host", required=True,
+        help="host name of the component",
+    )
+    parser.add_argument(
+        "-P", "--port", default="8080",
+        help="port number of the component (default: %(default)s)",
+    )
+    parser.add_argument(
+        "-E", "--endpoint", default="/sys/info/health",
+        help="health endpoint (default: %(default)s)",
+    )
+    return parser
+
+
 class RequestError(Exception):
 
     def __init__(self, message):
         self.message = message
-
-
-def generate_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-H",
-        "--host",
-        action="store",
-        required=True,
-        help="Host")
-    parser.add_argument(
-        '-P',
-        '--port',
-        action="store",
-        required=True,
-        help="Port")
-    parser.add_argument(
-        "-E",
-        "--endpoint",
-        action="store",
-        required=False,
-        help="Endpoint",
-        default="/sys/info/health")
-    return parser
 
 
 def do_request(host, port, endpoint):

--- a/plugins/default/lib/component_health.py
+++ b/plugins/default/lib/component_health.py
@@ -32,6 +32,9 @@ class RequestError(Exception):
     def __init__(self, message):
         self.message = message
 
+    def __str__(self):
+        return self.message
+
 
 def do_request(host, port, endpoint):
     url = 'http://%s:%s%s' % (host, port, endpoint)

--- a/plugins/default/lib/component_health.py
+++ b/plugins/default/lib/component_health.py
@@ -75,8 +75,8 @@ def report(summary, test_results):
 
 
 def main():
+    args = generate_parser().parse_args()
     try:
-        args = generate_parser().parse_args()
         host = args.host
         port = args.port
         endpoint = args.endpoint

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -62,6 +62,9 @@ def analize(pod, disks, warning_threshold, critical_threshold):
 
 
 def report(results):
+    if not results:
+        return nagios.UNKNOWN
+
     unique_statuses = Counter(
         disk_status
         for pod, mount, space_usage, inode_usage, disk_status in results
@@ -115,5 +118,3 @@ if __name__ == "__main__":
         traceback.print_exc()
     finally:
         sys.exit(code)
-
-# TODO: what if nothing is checked? (empty output from df, etc)

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -9,21 +9,28 @@ import openshift
 import nagios
 
 
+def generate_parser():
+    parser = argparse.ArgumentParser(
+        description="Checks the disk usage (blocks and inodes)",
+    )
+    parser.add_argument(
+        "-w", "--warn", type=int, required=True,
+        help="set warning threshold of disk usage (%% of blocks or inodes)",
+    )
+    parser.add_argument(
+        "-c", "--crit", type=int, required=True,
+        help="set critical threshold of disk usage (%% of blocks or inodes), "
+             "must be higher than or equal the warning threshold",
+    )
+    return parser
+
+
 check_disk_cmd = ("df", "--output=pcent,ipcent,target")
 # Example output:
 # Use% IUse% Mounted on
 #   1%    1% /
 #  20%    8% /etc/hosts
 check_disk_output_pattern = re.compile(r"\s*(\d+)%\s+(\d+)%\s+(.+)$")
-
-
-def generate_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--warn", type=int, action="store",
-                        required=True, help="Warning Threshold")
-    parser.add_argument('-c', '--crit', type=int, action="store",
-                        required=True, help="Critical Threshold")
-    return parser
 
 
 def parse_df_line(line):

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -11,7 +11,9 @@ import nagios
 
 check_disk_cmd = ("df", "--output=pcent,ipcent,target")
 # Example output:
-# /etc/hosts      19%    8%
+# Use% IUse% Mounted on
+#   1%    1% /
+#  20%    8% /etc/hosts
 check_disk_output_pattern = re.compile(r"\s*(\d+)%\s+(\d+)%\s+(.+)$")
 
 


### PR DESCRIPTION
This is making the structure of the existing checks more similar to facilitate adding new checks in the same style.

Each script looks like:

```python
#!/usr/bin/env python
import ...
import sys
import traceback

import nagios


def generate_parser():
    parser = argparse.ArgumentParser(
        description="...",
    )
    parser.add_argument(
        # ...
    )
    # ...
    return parser


# ...


def check(...):
    # ...
    # return nagios codes
    return nagios.OK


if __name__ == "__main__":
    args = generate_parser().parse_args()
    code = nagios.UNKNOWN
    try:
        code = check(...)
    except:
        traceback.print_exc()
    finally:
        sys.exit(code)
```

## Functional changes

The functional changes squeezed in here:

- The `fh-check-component-health` check returns `UNKNOWN` instead of `CRIT` for connection errors
- Fixed exit codes for `disk-usage` check:  it only ever returned 0 (implicit when the script terminates) or UNKNOWN in case of errors other than CalledProcessError and KeyError (both incorrectly returned 0)