### PR TITLE
Adding support for mbaas 3 node template

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -87,7 +87,7 @@ define host {
 {% for fhservice in fh_services if 'ping' in fhservice['checks'] %}
 define service {
        service_description {{ fhservice['name'] }}::Ping
-       check_command check_fh_component_http_ping!{{ fhservice['name'] }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("ping_endpoint", "/sys/info/ping") }}
+       check_command check_fh_component_http_ping!{{ fhservice.get("service", fhservice['name']) }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("ping_endpoint", "/sys/info/ping") }}
        use generic-service
        hostgroup_name {{ ",".join(fhservice['hostgroups']) }}
        notes This server cannot access {{ fhservice['name'] }}, check it is running and that this server is able to talk to it on port 8080
@@ -98,7 +98,7 @@ define service {
 {% for fhservice in fh_services if 'health' in fhservice['checks'] %}
 define service {
        service_description {{ fhservice['name'] }}::Health
-       check_command check_fh_component_health!{{ fhservice['name'] }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("health_endpoint", "/sys/info/health") }}
+       check_command check_fh_component_health!{{ fhservice.get("service", fhservice['name']) }}!{{ fhservice.get("port", "8080") }}!{{ fhservice.get("health_endpoint", "/sys/info/health") }}
        use generic-service
        hostgroup_name {{ ",".join(fhservice['hostgroups']) }}
        notes This server failed to get a successful response from the {{ fhservice['name'] }} health endpoint. Check the response code & body and ensure the service and its dependencies are running and configured correctly.

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -5,15 +5,17 @@ import os
 from jinja2 import Environment, FileSystemLoader, Template
 
 fh_services = [
-    {'name': 'fh-messaging', 'checks': ['ping', 'health'], 'hostgroups': ['core', 'mbaas']},
-    {'name': 'fh-metrics', 'checks': ['ping', 'health'], 'hostgroups': ['core', 'mbaas']},
+    {'name': 'fh-messaging', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'fh-messaging','service': 'fh-messaging-service', 'checks': ['ping', 'health'], 'hostgroups': ['mbaas']},
+    {'name': 'fh-metrics', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
+    {'name': 'fh-metrics', 'service': 'fh-metrics-service', 'checks': ['ping', 'health'], 'hostgroups': ['mbaas']},
     {'name': 'fh-ngui', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
     {'name': 'fh-supercore', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
     {'name': 'fh-aaa', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
     {'name': 'fh-appstore', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
     {'name': 'fh-scm', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
-    {'name': 'fh-mbaas', 'checks': ['ping', 'health'], 'hostgroups': ['mbaas']},
-    {'name': 'fh-statsd', 'checks': ['ping'], 'hostgroups': ['mbaas']},
+    {'name': 'fh-mbaas', 'service': 'fh-mbaas-service', 'checks': ['ping', 'health'], 'hostgroups': ['mbaas']},
+    {'name': 'fh-statsd', 'service': 'fh-statsd-service', 'checks': ['ping'], 'hostgroups': ['mbaas']},
     {'name': 'millicore', 'checks': ['health'], 'health_endpoint': '/box/api/health', 'hostgroups': ['core']},
     {'name': 'ups', 'checks': ['health'], 'health_endpoint': '/ag-push/rest/sys/info/health', 'hostgroups': ['core']}
 ]


### PR DESCRIPTION
This change is required to support the existing 3 node mbaas template where the service names are different to what we have in our core templates, see related Jira.

**Related Jira**
https://issues.jboss.org/browse/RHMAP-9521

**Validation**
Deploy version 4.0.8-93 of the nagios docker image within a Core and MBaaS project. Ensure all expected checks are displayed and passing