### PR TITLE
Updating nagios host alive check to use check_ping plugin

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -23,8 +23,8 @@ define command {
 }
 
 define command {
-       command_name   check_nagios_host
-       command_line   $USER1$/check_http -H $HOSTADDRESS$ -S
+       command_name   check_nagios_host_alive
+       command_line   $USER1$/check_ping -H $HOSTADDRESS$ -w 3000,100% -c 5000,100% -p 1
 }
 
 define command {
@@ -68,7 +68,7 @@ define host {
   check_interval          5
   retry_interval          1
   max_check_attempts      10
-  check_command           check_nagios_host
+  check_command           check_nagios_host_alive
   notification_period     workhours
   notification_interval   120
   notification_options    d,u,r


### PR DESCRIPTION
**Overview**
At the moment our MBaaS 3 node template does not have a requirement to have parameters passed in for MBAAS_ROUTER_DNS. When adding Nagios to this template, there is an issue where the nagios host does not get set due to MBAAS_ROUTER_DNS not being passed in. To resolve this issue, we need to instead update the MBaaS 3 node template to use localhost by default and change the default host health check to use check_ping rather than check_http as localhost on Nagios does not have 80 or 443 port running.

**Related Jiras:**
https://issues.jboss.org/browse/RHMAP-9693

**Validation**
Use this Nagios image (docker.io/rhmap/nagios4:4.0.8-96
 as part of a Core and MBaaS project and ensure that the Nagios host is not showing up as red