### PR TITLE
Rhmap 9311 memory checks

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -33,6 +33,11 @@ define command {
 }
 
 define command {
+  command_name   check_pod_memory_usage
+  command_line   /opt/rhmap/nagios/plugins/memory-usage -w $ARG1$ -c $ARG2$
+}
+
+define command {
   command_name   check_mongodb
   command_line   /opt/rhmap/nagios/plugins/mongodb-health --container $ARG1$
 }
@@ -139,5 +144,14 @@ define service {
        use generic-service
        hostgroup_name core,mbaas
        notes The mongodb replica set may not be functioning properly.  There should be one and only one primary member and zero or more secondary members
+       contact_groups rhmapadmins
+}
+
+define service {
+       service_description Container::Memory Usage
+       check_command check_pod_memory_usage!80!90
+       use generic-service
+       hostgroup_name core,mbaas
+       notes One or more containers are running out of memory.
        contact_groups rhmapadmins
 }

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -106,7 +106,7 @@ def check(warn, crit, minimum):
 
     pcs = openshift.get_running_pod_containers(project)
 
-    for pod_name, container_name in pcs:
+    for pod_name, container_name, container_data in pcs:
         try:
             result = openshift.exec_in_pod_container(project, pod_name, container_name, check_disk_cmd)
 

--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -27,6 +27,10 @@ def generate_parser():
         help="set minimum threshold of disk usage  (%% of blocks or inodes), "
              "details will only be reported for volumes over this value",
     )
+    parser.add_argument(
+        "-p", "--project", required=False,
+        help="openshift project/namespace to use",
+    )
     return parser
 
 
@@ -94,12 +98,13 @@ def report(results, errors, minimum):
     return ret
 
 
-def check(warn, crit, minimum):
+def check(warn, crit, minimum, project):
     if crit < warn:
         msg = "critical threshold cannot be lower than warning threshold: %d < %d"
         raise ValueError(msg % (crit, warn))
 
-    project = openshift.get_project()
+    if not project:
+        project = openshift.get_project()
 
     results = []
     errors = []
@@ -121,7 +126,7 @@ if __name__ == "__main__":
     args = generate_parser().parse_args()
     code = nagios.UNKNOWN
     try:
-        code = check(args.warn, args.crit, args.minimum)
+        code = check(args.warn, args.crit, args.minimum, args.project)
     except:
         traceback.print_exc()
     finally:

--- a/plugins/default/lib/memory_usage.py
+++ b/plugins/default/lib/memory_usage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+import argparse
+import sys
+import traceback
+from collections import Counter
+
+import openshift
+import nagios
+
+
+def generate_parser():
+    parser = argparse.ArgumentParser(
+        description="Checks container memory usage",
+    )
+    parser.add_argument(
+        "-w", "--warn", type=int, required=True,
+        help="set warning threshold percentage",
+    )
+    parser.add_argument(
+        "-c", "--crit", type=int, required=True,
+        help="set critical threshold percentage, "
+             "must be higher than or equal the warning threshold",
+    )
+    return parser
+
+
+check_memory_usage_cmd = ("cat", "/sys/fs/cgroup/memory/memory.usage_in_bytes")
+check_memory_limit_cmd = ("cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+
+def analize(pod, container, memory_limit, memory_used, warning_threshold, critical_threshold):
+    results = []
+    usage = (float(memory_used) / float(memory_limit)) * 100
+
+    nagios_status = nagios.UNKNOWN
+    if usage >= critical_threshold:
+        nagios_status = nagios.CRIT
+    elif usage >= warning_threshold:
+        nagios_status = nagios.WARN
+    elif usage < warning_threshold:
+        nagios_status = nagios.OK
+
+    results.append([pod, container, int(memory_limit), int(memory_used), usage, nagios_status])
+    return results
+
+
+def report(results, errors):
+    if not results:
+        return nagios.UNKNOWN
+
+    unique_statuses = Counter(
+        status
+        for pod, container, memory_total, memory_used, usage, status in results
+    )
+
+    ret = max(unique_statuses)
+
+    if ret == nagios.OK:
+        print "%s: All %s containers are under the warning threshold" % (
+            nagios.status_code_to_label(ret), len(results))
+    elif ret == nagios.UNKNOWN:
+        print "%s: Unable to determine usage on %s containers" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.UNKNOWN])
+    elif ret == nagios.WARN:
+        print "%s: There are %s containers over the warning threshold" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.WARN])
+    else:
+        print "%s: There are %s containers over the critical threshold and %s containers over the warning threshold" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.CRIT], unique_statuses[nagios.WARN])
+
+    for pod, container, memory_total, memory_used, usage, status in results:
+        print "%s: %s: - usage: %.1f%%" % (
+            nagios.status_code_to_label(status), pod, usage)
+
+    if errors:
+        ret = nagios.UNKNOWN
+        for pod_name, container_name, ex in errors:
+            print "%s: %s:%s %s" % (
+                nagios.status_code_to_label("WARNING"), pod_name, container_name, ex)
+
+    return ret
+
+
+def check(warn, crit):
+    if crit < warn:
+        msg = "critical threshold cannot be lower than warning threshold: %d < %d"
+        raise ValueError(msg % (crit, warn))
+
+    project = openshift.get_project()
+
+    results = []
+    errors = []
+
+    pcs = openshift.get_running_pod_containers(project)
+
+    for pod_name, container_name, container_data in pcs:
+        memory_limit = container_data.get('resources', {}).get('limits', {}).get('memory')
+        try:
+            memory_usage = openshift.exec_in_pod_container(
+                project, pod_name, container_name, check_memory_usage_cmd)
+            if memory_limit:
+                memory_limit = openshift.exec_in_pod_container(
+                    project, pod_name, container_name, check_memory_limit_cmd)
+                results.extend(analize(pod_name, container_name, memory_limit, memory_usage, warn, crit))
+        except Exception as e:
+            errors.append((pod_name, container_name, e))
+
+    return report(results, errors)
+
+if __name__ == "__main__":
+    args = generate_parser().parse_args()
+    code = nagios.UNKNOWN
+    try:
+        code = check(args.warn, args.crit)
+    except:
+        traceback.print_exc()
+    finally:
+        sys.exit(code)

--- a/plugins/default/lib/memory_usage.py
+++ b/plugins/default/lib/memory_usage.py
@@ -21,6 +21,10 @@ def generate_parser():
         help="set critical threshold percentage, "
              "must be higher than or equal the warning threshold",
     )
+    parser.add_argument(
+        "-p", "--project", required=False,
+        help="openshift project/namespace to use",
+        )
     return parser
 
 
@@ -81,12 +85,13 @@ def report(results, errors):
     return ret
 
 
-def check(warn, crit):
+def check(warn, crit, project):
     if crit < warn:
         msg = "critical threshold cannot be lower than warning threshold: %d < %d"
         raise ValueError(msg % (crit, warn))
 
-    project = openshift.get_project()
+    if not project:
+        project = openshift.get_project()
 
     results = []
     errors = []
@@ -111,7 +116,7 @@ if __name__ == "__main__":
     args = generate_parser().parse_args()
     code = nagios.UNKNOWN
     try:
-        code = check(args.warn, args.crit)
+        code = check(args.warn, args.crit, args.project)
     except:
         traceback.print_exc()
     finally:

--- a/plugins/default/lib/openshift.py
+++ b/plugins/default/lib/openshift.py
@@ -72,7 +72,7 @@ def _get_running_pod_containers(oc, project, selector=None):
     for p in pods:
         if p["status"]["phase"] == "Running":
             for c in p["spec"]["containers"]:
-                result.append((p["metadata"]["name"], c["name"]))
+                result.append((p["metadata"]["name"], c["name"], c))
 
     return result
 

--- a/plugins/default/lib/test_memory_usage.py
+++ b/plugins/default/lib/test_memory_usage.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+from subprocess import CalledProcessError
+import unittest
+
+from memory_usage import analize, report
+import nagios
+
+
+class TestAnalize(unittest.TestCase):
+
+    def runTest(self):
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 100, 0, 0),
+            ([
+                ['pod-a1b2c', 'container1', 100, 100, 100, nagios.CRIT],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 10, 0, 0),
+            ([
+                ['pod-a1b2c', 'container1', 100, 10, 10.0, nagios.CRIT],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 49, 50, 60),
+            ([
+                ['pod-a1b2c', 'container1', 100, 49, 49.0, nagios.OK],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 50, 50, 60),
+            ([
+                ['pod-a1b2c', 'container1', 100, 50, 50.0, nagios.WARN],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 59, 50, 60),
+            ([
+                ['pod-a1b2c', 'container1', 100, 59, 59.0, nagios.WARN],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 60, 50, 60),
+            ([
+                ['pod-a1b2c', 'container1', 100, 60, 60.0, nagios.CRIT],
+            ]))
+        self.assertEqual(analize(
+            'pod-a1b2c', 'container1', 100, 100, 50, 60),
+            ([
+                ['pod-a1b2c', 'container1', 100, 100, 100.0, nagios.CRIT],
+            ]))
+
+
+class TestReport(unittest.TestCase):
+
+    def runTest(self):
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 100, 49, 49.0, nagios.OK],
+                    ['pod-a1b2c', 'container2', 100, 49, 49.0, nagios.OK]
+                ],
+                errors=(),
+            ), nagios.OK)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 100, 49, 49.0, nagios.OK],
+                    ['pod-a1b2c', 'container2', 100, 50, 50.0, nagios.WARN]
+                ],
+                errors=(),
+            ), nagios.WARN)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 100, 49, 49.0, nagios.OK],
+                    ['pod-a1b2c', 'container2', 100, 50, 50.0, nagios.WARN],
+                    ['pod-a1b2c', 'container3', 100, 100, 100.0, nagios.CRIT]
+                ],
+                errors=(),
+            ), nagios.CRIT)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 100, 100, 100.0, nagios.CRIT],
+                    ['pod-a1b2c', 'container2', 100, 100, 100.0, nagios.UNKNOWN]
+                ],
+                errors=(),
+            ), nagios.UNKNOWN)
+        self.assertEqual(
+            report(
+                results=[
+                ],
+                errors=(),
+            ), nagios.UNKNOWN)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 100, 49, 49.0, nagios.OK],
+                ],
+                errors=(
+                    (
+                        'pod-a1b2c',
+                        'bad-container',
+                        CalledProcessError(
+                            1,
+                            cmd=(
+                                'oc', '-n', 'core', 'exec', 'pod-a1b2c', '-c',
+                                'bad-container', '--', 'df', '--output=pcent,ipcent,target'
+                            ),
+                            output=(
+                                "Command '('oc', '-n', 'core', 'exec', 'pod-a1b2c', '-c', 'bad-container', "
+                                "'--', 'df', '--output=pcent,ipcent,target')' returned non-zero exit status 1"
+                            )
+                        )
+                    ),
+                )
+            ), nagios.UNKNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/default/memory-usage
+++ b/plugins/default/memory-usage
@@ -1,0 +1,1 @@
+lib/memory_usage.py


### PR DESCRIPTION
* Adds new memory nagios checks. Will warn of any issues in running containers that have a memory limit set (Future work to check that limits have been set)
![rhmap9311_memory_check](https://cloud.githubusercontent.com/assets/327352/17899789/616e391a-6954-11e6-86b1-922f5b24808f.png)
* Adds an optional 'project' argument to both the memory and disk checks to make them easier to test. Default is still the currently configured openshift namespace as before.

```
$ ./memory-usage -w 80 -c 90 -p core
OK: All 6 containers are under the warning threshold
OK: fh-messaging-1-i9zy8: - total bytes: 419430400.0 used bytes: 131399680.0 usage: 31.3%
OK: fh-metrics-1-73ho5: - total bytes: 419430400.0 used bytes: 75399168.0 usage: 18.0%
OK: memcached-1-xrabe: - total bytes: 1073741824.0 used bytes: 18030592.0 usage: 1.7%
OK: mongodb-1-1-olaua: - total bytes: 1048576000.0 used bytes: 145178624.0 usage: 13.8%
OK: mysql-1-g3eu1: - total bytes: 1073741824.0 used bytes: 705085440.0 usage: 65.7%
OK: redis-1-euurs: - total bytes: 524288000.0 used bytes: 11657216.0 usage: 2.2%

$ ./disk-usage -w 80 -c 90 -p core
Checked 112 volumes (0 critical, 0 warning)
OK: fh-aaa-1-2c597:fh-aaa:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-appstore-1-eqbzs:fh-appstore:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-messaging-1-i9zy8:fh-messaging:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-metrics-1-73ho5:fh-metrics:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-ngui-1-ku07y:fh-ngui:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-scm-1-hzd4j:fh-scm:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: fh-supercore-1-stttq:fh-supercore:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: gitlab-shell-1-j5nm7:gitlab-shell:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: gitlab-shell-1-j5nm7:gitlab-httpd-proxy:/srv - bytes used: 13%, inodes used: 3%
OK: memcached-1-xrabe:memcached:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: millicore-1-3wou4:millicore:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: millicore-1-3wou4:rhmap-proxy:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: millicore-1-3wou4:feedhenry-sdks:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: mongodb-1-1-olaua:mongodb:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: mysql-1-g3eu1:mysql:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: nagios-2-vafi4:nagios:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: redis-1-euurs:redis:/etc/hosts - bytes used: 13%, inodes used: 3%
OK: ups-1-pmq35:ups:/etc/hosts - bytes used: 13%, inodes used: 3%

```