### PR TITLE
RHMAP-9312 - Add container cpu usage nagios check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+cpu-usage-data.json

--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -38,6 +38,11 @@ define command {
 }
 
 define command {
+  command_name   check_pod_cpu_usage
+  command_line   /opt/rhmap/nagios/plugins/cpu-usage -w $ARG1$ -c $ARG2$
+}
+
+define command {
   command_name   check_mongodb
   command_line   /opt/rhmap/nagios/plugins/mongodb-health --container $ARG1$
 }
@@ -153,5 +158,14 @@ define service {
        use generic-service
        hostgroup_name core,mbaas
        notes One or more containers are running out of memory.
+       contact_groups rhmapadmins
+}
+
+define service {
+       service_description Container::CPU Usage
+       check_command check_pod_cpu_usage!80!90
+       use generic-service
+       hostgroup_name core,mbaas
+       notes One or more containers have a high CPU load.
        contact_groups rhmapadmins
 }

--- a/plugins/default/cpu-usage
+++ b/plugins/default/cpu-usage
@@ -1,0 +1,1 @@
+lib/cpu_usage.py

--- a/plugins/default/lib/cpu_usage.py
+++ b/plugins/default/lib/cpu_usage.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+import argparse
+import sys
+import traceback
+import json
+from collections import Counter
+
+import openshift
+import nagios
+
+
+CPU_USAGE_DATA_FILE = 'cpu-usage-data.json'
+
+
+def generate_parser():
+    parser = argparse.ArgumentParser(
+        description="Checks container cpu usage",
+    )
+    parser.add_argument(
+        "-w", "--warn", type=int, required=True,
+        help="set warning threshold percentage",
+    )
+    parser.add_argument(
+        "-c", "--crit", type=int, required=True,
+        help="set critical threshold percentage, "
+             "must be higher than or equal the warning threshold",
+    )
+    parser.add_argument(
+        "-p", "--project", required=False,
+        help="openshift project/namespace to use",
+    )
+    return parser
+
+
+# Returns elapsed time in seconds
+check_uptime_cmd = ("ps", "-p",  "1", "-o", "etimes:1=")
+# Returns usage in nanoseconds
+check_cpu_usage_cmd = ("cat", "/sys/fs/cgroup/cpuacct,cpu/cpuacct.usage")
+# Returns quota in microseconds
+check_cpu_limit_cmd = ("cat", "/sys/fs/cgroup/cpuacct,cpu/cpu.cfs_quota_us")
+
+
+def get_container_cpu_usage(project, pod, container):
+    usage = openshift.exec_in_pod_container(project, pod, container, check_cpu_usage_cmd)
+    uptime = openshift.exec_in_pod_container(project, pod, container, check_uptime_cmd)
+    limit = openshift.exec_in_pod_container(project, pod, container, check_cpu_limit_cmd)
+
+    usage = int(usage)  # Usage in nanoseconds
+    uptime = int(uptime) * 1000000000  # uptime in nanoseconds
+    limit = int(limit) / 100  # Limit in millicores
+
+    return usage, uptime, limit
+
+# https://github.com/openshift/origin-metrics/blob/master/docs/hawkular_metrics.adoc#calculating-percentage-cpu-usage
+# usage_start - usage start in nanoseconds
+# usage_end - usage end in nanoseconds
+# uptime_start - uptime start in nanoseconds
+# uptime_end - uptime end in nanoseconds
+# limit - limit set in millicores
+
+
+def calculate_limit_usage(usage_start, usage_end, uptime_start, uptime_end,  limit):
+    usage = usage_end - usage_start
+    uptime = uptime_end - uptime_start
+
+    core_usage = float(usage) / float(uptime)
+    limit_usage = (core_usage * 1000) / limit
+    limit_usage_pcent = limit_usage * 100
+
+    return limit_usage_pcent
+
+
+def read_cpu_usage():
+    try:
+        json_data = open(CPU_USAGE_DATA_FILE).read()
+        data = json.loads(json_data)
+    except IOError:
+        data = {}
+    return data
+
+
+def write_cpu_usage(data):
+    f = open(CPU_USAGE_DATA_FILE, 'w')
+    f.write(json.dumps(data))
+    f.close()
+
+
+def analize(pod, container, prev_usage, curr_usage, prev_uptime, curr_uptime, limit,
+            warning_threshold, critical_threshold):
+    results = []
+
+    if prev_usage is not None and prev_uptime is not None:
+        limit_percentage = calculate_limit_usage(prev_usage, curr_usage, prev_uptime, curr_uptime, limit)
+
+        nagios_status = nagios.UNKNOWN
+        if limit_percentage >= critical_threshold:
+            nagios_status = nagios.CRIT
+        elif limit_percentage >= warning_threshold:
+            nagios_status = nagios.WARN
+        elif limit_percentage < warning_threshold:
+            nagios_status = nagios.OK
+
+        results.append([pod, container, limit_percentage, nagios_status])
+
+    return results
+
+
+def report(results, errors):
+    if not results:
+        return nagios.UNKNOWN
+
+    unique_statuses = Counter(
+        status
+        for pod, container, usage, status in results
+    )
+
+    ret = max(unique_statuses)
+
+    if ret == nagios.OK:
+        print "%s: All %s containers are under the warning threshold" % (
+            nagios.status_code_to_label(ret), len(results))
+    elif ret == nagios.UNKNOWN:
+        print "%s: Unable to determine usage on %s containers" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.UNKNOWN])
+    elif ret == nagios.WARN:
+        print "%s: There are %s containers over the warning threshold" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.WARN])
+    else:
+        print "%s: There are %s containers over the critical threshold and %s containers over the warning threshold" % (
+            nagios.status_code_to_label(ret), unique_statuses[nagios.CRIT], unique_statuses[nagios.WARN])
+
+    for pod, container, usage, status in results:
+        print "%s: %s: - usage: %.2f%%" % (
+            nagios.status_code_to_label(status), pod, usage)
+
+    if errors:
+        ret = nagios.UNKNOWN
+        for pod_name, container_name, ex in errors:
+            print "%s: %s:%s %s" % (
+                nagios.status_code_to_label("WARNING"), pod_name, container_name, ex)
+
+    return ret
+
+
+def check(warn, crit, project):
+    if crit < warn:
+        msg = "critical threshold cannot be lower than warning threshold: %d < %d"
+        raise ValueError(msg % (crit, warn))
+
+    if not project:
+        project = openshift.get_project()
+
+    results = []
+    errors = []
+
+    prev_cpu_usage = read_cpu_usage()
+    curr_cpu_usage = {}
+    pcs = openshift.get_running_pod_containers(project)
+
+    for pod_name, container_name, container_data in pcs:
+        cpu_limit = container_data.get('resources', {}).get('limits', {}).get('cpu')
+        try:
+            if cpu_limit:
+                curr_usage, curr_uptime, limit = get_container_cpu_usage(project, pod_name, container_name)
+                curr_cpu_usage[pod_name] = {container_name: [curr_usage, curr_uptime]}
+                prev_usage, prev_uptime = prev_cpu_usage.get(pod_name, {}).get(container_name, [None, None])
+                results.extend(analize(pod_name, container_name, prev_usage,
+                                       curr_usage, prev_uptime, curr_uptime, limit, warn, crit))
+        except Exception as e:
+            errors.append((pod_name, container_name, e))
+
+    write_cpu_usage(curr_cpu_usage)
+    return report(results, errors)
+
+if __name__ == "__main__":
+    args = generate_parser().parse_args()
+    code = nagios.UNKNOWN
+    try:
+        code = check(args.warn, args.crit, args.project)
+    except:
+        traceback.print_exc()
+    finally:
+        sys.exit(code)

--- a/plugins/default/lib/test_cpu_usage.py
+++ b/plugins/default/lib/test_cpu_usage.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+from subprocess import CalledProcessError
+import unittest
+
+from cpu_usage import calculate_limit_usage, analize, report
+import nagios
+
+
+class TestCalculateLimitUsage(unittest.TestCase):
+
+    def runTest(self):
+        self.assertEqual(calculate_limit_usage(0, 10, 0, 1000, 1000), 1.0)
+        self.assertEqual(calculate_limit_usage(0, 15, 0, 1000, 1000), 1.5)
+        self.assertEqual(calculate_limit_usage(0, 100, 0, 1000, 1000), 10)
+        self.assertEqual(calculate_limit_usage(0, 1000, 0, 1000, 1000), 100)
+        self.assertEqual(calculate_limit_usage(100, 115, 100, 1100, 1000), 1.5)
+        self.assertEqual(calculate_limit_usage(100, 130, 100, 1100, 1000), 3.0)
+        self.assertEqual(calculate_limit_usage(100, 130, 100, 1100, 2000), 1.5)
+        self.assertEqual(calculate_limit_usage(100, 130, 100, 1100, 4000), 0.75)
+        self.assertEqual(calculate_limit_usage(100, 130, 100, 1100, 500), 6.0)
+
+
+class TestAnalize(unittest.TestCase):
+
+    def runTest(self):
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 80, 90), ([['pod-a1b2c', 'container1', 10.0, nagios.OK]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 11, 20), ([['pod-a1b2c', 'container1', 10.0, nagios.OK]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 10, 20), ([['pod-a1b2c', 'container1', 10.0, nagios.WARN]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 9, 20), ([['pod-a1b2c', 'container1', 10.0, nagios.WARN]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 5, 11), ([['pod-a1b2c', 'container1', 10.0, nagios.WARN]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 5, 10), ([['pod-a1b2c', 'container1', 10.0, nagios.CRIT]]))
+        self.assertEqual(analize('pod-a1b2c', 'container1', 0, 100, 0, 1000,
+                                 1000, 5, 9), ([['pod-a1b2c', 'container1', 10.0, nagios.CRIT]]))
+
+
+class TestReport(unittest.TestCase):
+
+    def runTest(self):
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK],
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK]
+                ],
+                errors=(),
+            ), nagios.OK)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK],
+                    ['pod-a1b2c', 'container1', 10.0, nagios.WARN]
+                ],
+                errors=(),
+            ), nagios.WARN)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK],
+                    ['pod-a1b2c', 'container1', 10.0, nagios.WARN],
+                    ['pod-a1b2c', 'container1', 10.0, nagios.CRIT]
+                ],
+                errors=(),
+            ), nagios.CRIT)
+        self.assertEqual(
+            report(
+                results=[
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK],
+                    ['pod-a1b2c', 'container1', 10.0, nagios.OK]
+                ],
+                errors=(
+                    (
+                        'pod-jf02k',
+                        'bad-container',
+                        CalledProcessError(
+                            1,
+                            cmd=(
+                                'oc', '-n', 'core', 'exec', 'pod-a1b2c', '-c',
+                                'bad-container', '--', 'df', '--output=pcent,ipcent,target'
+                            ),
+                            output=(
+                                "Command '('oc', '-n', 'core', 'exec', 'pod-a1b2c', '-c', 'bad-container', "
+                                "'--', 'df', '--output=pcent,ipcent,target')' returned non-zero exit status 1"
+                            )
+                        )
+                    ),
+                ),
+            ), nagios.UNKNOWN)
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Adds a new nagios check for CPU usage based on the limits set for the container. Uses the time elapsed between checks to work out how much CPU time was used. 
* Will display UNKNOWN status on the initial check since it requires 2 successful checks to take place before it can start calculating usage.

![rhmap9312_cpu_checks](https://cloud.githubusercontent.com/assets/327352/18056883/b8c0292a-6e05-11e6-8022-c13c9d3a8ed0.png)


Jira:

https://issues.jboss.org/browse/RHMAP-9312