### PR TITLE
RHMAP-9870 - Add ping checks for millicore and ups.

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -1,7 +1,7 @@
 # Check that a component responds to a /sys/info/ping over HTTP
 define command {
        command_name   check_fh_component_http_ping
-       command_line   $USER1$/check_http -H $ARG1$ -u /sys/info/ping -p 8080
+       command_line   $USER1$/check_http -H $ARG1$ -p $ARG2$ -u $ARG3$
 }
 
 # Check that a component responds to a /sys/info/health over HTTP

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -16,8 +16,8 @@ fh_services = [
     {'name': 'fh-scm', 'checks': ['ping', 'health'], 'hostgroups': ['core']},
     {'name': 'fh-mbaas', 'service': 'fh-mbaas-service', 'checks': ['ping', 'health'], 'hostgroups': ['mbaas']},
     {'name': 'fh-statsd', 'service': 'fh-statsd-service', 'checks': ['ping'], 'hostgroups': ['mbaas']},
-    {'name': 'millicore', 'checks': ['health'], 'health_endpoint': '/box/api/health', 'hostgroups': ['core']},
-    {'name': 'ups', 'checks': ['health'], 'health_endpoint': '/ag-push/rest/sys/info/health', 'hostgroups': ['core']}
+    {'name': 'millicore', 'checks': ['ping', 'health'], 'health_endpoint': '/box/api/health',  'ping_endpoint': '/box/srv/1.1/tst/version', 'hostgroups': ['core']},
+    {'name': 'ups', 'checks': ['ping', 'health'], 'health_endpoint': '/ag-push/rest/sys/info/health', 'ping_endpoint': '/ag-push/rest/sys/info/ping', 'hostgroups': ['core']}
 ]
 
 rhmap_admin_email = os.getenv('RHMAP_ADMIN_EMAIL', 'root@localhost')


### PR DESCRIPTION
* Add ping checks for millicore and ups.
* Modified check_fh_component_http_ping to use args being passed to it.

![rhmap9870_mc_and_ups_ping_checks](https://cloud.githubusercontent.com/assets/327352/18095755/d105ec34-6ecf-11e6-9d81-84d67cd661c3.png)

Jira:

https://issues.jboss.org/browse/RHMAP-9870