### PR TITLE
RHMAP-9900 - Remove incompatible mongodb check from core

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -164,10 +164,10 @@ define service {
 }
 
 define service {
-       service_description mongodb:health
+       service_description mongodb::replicaset
        check_command check_mongodb!mongodb,mongodb-service,mongodb-1
        use generic-service
-       hostgroup_name core,mbaas
+       hostgroup_name mbaas
        notes The mongodb replica set may not be functioning properly.  There should be one and only one primary member and zero or more secondary members
        contact_groups rhmapadmins
 }

--- a/plugins/default/lib/cpu_usage.py
+++ b/plugins/default/lib/cpu_usage.py
@@ -130,8 +130,8 @@ def report(results, errors):
             nagios.status_code_to_label(ret), unique_statuses[nagios.CRIT], unique_statuses[nagios.WARN])
 
     for pod, container, usage, status in results:
-        print "%s: %s: - usage: %.2f%%" % (
-            nagios.status_code_to_label(status), pod, usage)
+        print "%s: %s:%s: - usage: %.2f%%" % (
+            nagios.status_code_to_label(status), pod, container, usage)
 
     if errors:
         ret = nagios.UNKNOWN
@@ -162,7 +162,8 @@ def check(warn, crit, project):
         try:
             if cpu_limit:
                 curr_usage, curr_uptime, limit = get_container_cpu_usage(project, pod_name, container_name)
-                curr_cpu_usage[pod_name] = {container_name: [curr_usage, curr_uptime]}
+                curr_cpu_usage[pod_name] = curr_cpu_usage.get(pod_name, {})
+                curr_cpu_usage[pod_name][container_name] = [curr_usage, curr_uptime]
                 prev_usage, prev_uptime = prev_cpu_usage.get(pod_name, {}).get(container_name, [None, None])
                 results.extend(analize(pod_name, container_name, prev_usage,
                                        curr_usage, prev_uptime, curr_uptime, limit, warn, crit))

--- a/plugins/default/lib/memory_usage.py
+++ b/plugins/default/lib/memory_usage.py
@@ -73,8 +73,8 @@ def report(results, errors):
             nagios.status_code_to_label(ret), unique_statuses[nagios.CRIT], unique_statuses[nagios.WARN])
 
     for pod, container, memory_total, memory_used, usage, status in results:
-        print "%s: %s: - usage: %.1f%%" % (
-            nagios.status_code_to_label(status), pod, usage)
+        print "%s: %s:%s: - usage: %.1f%%" % (
+            nagios.status_code_to_label(status), pod, container, usage)
 
     if errors:
         ret = nagios.UNKNOWN


### PR DESCRIPTION
* Rename mongodb replicaset health check
* Only apply replicaset check to the mbaas.
* Fix an issue where the cpu check wasn't working for pods with more than one container.
* Add pod and container name to memory and cpu check output: 

```
$ ./cpu-usage -c 90 -w 80 -p core
...
OK: millicore-1-topoi:millicore: - usage: 0.35%
OK: millicore-1-topoi:rhmap-proxy: - usage: 0.16%
OK: millicore-1-topoi:feedhenry-sdks: - usage: 0.15%
...
```

Jira:

https://issues.jboss.org/browse/RHMAP-9900