### PR TITLE
add mongodb ping check

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -54,6 +54,11 @@ define command {
 }
 
 define command {
+  command_name   check_mongodb_ping
+  command_line   $USER1$/check_tcp -H $ARG1$ -p $ARG2$ -w2 -c5 -t5
+}
+
+define command {
   command_name   check_mysql
   command_line   /opt/rhmap/nagios/plugins/mysql-health --service $ARG1$ --containers $ARG2$ 
 }
@@ -171,6 +176,17 @@ define service {
        notes The mongodb replica set may not be functioning properly.  There should be one and only one primary member and zero or more secondary members
        contact_groups rhmapadmins
 }
+
+{% for mongodb_service in mongodb_services %}
+define service {
+  service_description {{ mongodb_service }}:Ping
+  check_command check_mongodb_ping!{{ mongodb_service }}!27017
+  use generic-service
+  hostgroup_name core,mbaas
+  notes This should be able to communicate with mongodb on port 27017 and cannot. Check it is running and this server can communicate with it on that port.
+  contact_groups rhmapadmins
+}
+{% endfor %}
 
 define service {
        service_description mysql::health

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -24,6 +24,13 @@ rhmap_admin_email = os.getenv('RHMAP_ADMIN_EMAIL', 'root@localhost')
 rhmap_router_dns = os.getenv('RHMAP_ROUTER_DNS', 'localhost')
 rhmap_hostgroups = os.getenv('RHMAP_HOSTGROUPS', 'core')
 
+if rhmap_hostgroups == 'mbaas':
+    mongodb_count = int(os.getenv("MONGODB_ENDPOINT_COUNT", 3))
+else:
+    mongodb_count = 1
+
+mongodb_services = [('mongodb-' + str(i)) for i in range(1, (mongodb_count + 1))]
+
 template_file = '/opt/rhmap/fhservices.cfg.j2'
 nagios_config_filename = '/etc/nagios/conf.d/fhservices.cfg'
 
@@ -34,6 +41,7 @@ j2env = Environment(loader=FileSystemLoader(template_dirname), trim_blocks=True)
 j2template = j2env.get_template(template_basename)
 
 j2renderedouput = j2template.render(fh_services=fh_services,
+                                    mongodb_services=mongodb_services,
                                     rhmap_hostgroups=rhmap_hostgroups,
                                     rhmap_router_dns=rhmap_router_dns,
                                     rhmap_admin_email=rhmap_admin_email)


### PR DESCRIPTION
JIRA: [RHMAP-9934](https://issues.jboss.org/browse/RHMAP-9934)

Adds mongodb "ping" checks via check_tcp, adds support for make-nagios-fhservices-cfg script to determine the names of the mongodb service(s) based on template parameters (core vs. mbaas).  Defaults to 3 for mbaas if parameter is not found as the 1 node mbaas template doesn't include nagios anyway.
