### PR TITLE
RHMAP-10153: Creating log dirs in start.sh script to support PVs

### DIFF
--- a/start
+++ b/start
@@ -1,5 +1,10 @@
 #!/usr/bin/bash
 
+# Add nagios dirs
+mkdir -p /var/log/nagios/archives \
+      /var/log/nagios/rw \
+      /var/log/nagios/spool/checkresults
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
**Overview**
In this sprint we have a task to add support for persistent volumes in Nagios. However, an issue was uncovered where some log directories are not being created on startup causing the Nagios dashboard services page to throw an error. As it turns out we used to create these directories as part of startup in the mbaas-monitoring repo [1]

[1] https://github.com/feedhenry/mbaas-monitoring/blob/master/start.sh#L4-L6

**Related Jiras**
https://issues.jboss.org/browse/RHMAP-10153