### PR TITLE
Rhmap 10225 status helper scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN yum install -y epel-release && \
 COPY supervisord.conf /etc/supervisord.conf
 COPY make-nagios-fhservices-cfg make-nagios-commands-cfg fhservices.cfg.j2 commands.cfg.j2 /opt/rhmap/
 COPY plugins/default/ /opt/rhmap/nagios/plugins/
+COPY scripts/ /opt/rhmap/
 RUN chmod -R 755 /opt/rhmap/nagios/plugins/
 COPY start /start
 

--- a/scripts/check-status
+++ b/scripts/check-status
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import os
+import sys
+import json
+import urllib2
+import base64
+
+# Codes returned from the API are different from the normal nagios status codes
+# nagios_service_status = {'1' => 'pending', '2' => 'ok', '4' => 'warning', '8' => 'unknown', '16' => 'critical' };
+
+host = os.getenv('RHMAP_ROUTER_DNS', 'localhost')
+port = os.getenv('NAGIOS_SERVICE_PORT', 8080)
+nagios_user = os.getenv('NAGIOS_USER', 'nagiosadmin')
+nagios_pass = os.getenv('NAGIOS_PASSWORD', 'password')
+
+url = 'http://%s:%s/nagios/cgi-bin/statusjson.cgi?query=servicelist' % (host,port)
+
+request = urllib2.Request(url)
+base64string = base64.b64encode('%s:%s' % (nagios_user, nagios_pass))
+request.add_header("Authorization", "Basic %s" % base64string)
+resp = urllib2.urlopen(request).read()
+data = json.loads(resp)
+
+exit_status = 0
+if data['data']['servicelist'][host]:
+    for check, status in data['data']['servicelist'][host].items():
+        print 'Service Check: %s, Status Code: %s' % (check, status)
+        if status != 2:
+            exit_status = 1
+
+else:
+    print "No service checks defined for host '%s'" % (host)
+    exit_status = 1
+
+sys.exit(exit_status)

--- a/scripts/host-svc-check
+++ b/scripts/host-svc-check
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+import time
+
+host = os.getenv('RHMAP_ROUTER_DNS', 'localhost')
+nagios_cmd_file = os.getenv('NAGIOS_CMD_FILE', '/var/spool/nagios/cmd/nagios.cmd')
+
+
+# https://old.nagios.org/developerinfo/externalcommands/commandinfo.php?command_id=130
+def force_service_checks():
+    print "Forcing service checks on '%s' ..." % (host)
+
+    with open(nagios_cmd_file, "a") as f:
+        cmd = "[%s] SCHEDULE_FORCED_HOST_SVC_CHECKS;%s;1110741500\n" % (int(time.time()),host)
+        f.write(cmd)
+
+    print 'Waiting 20s ...'
+    time.sleep(20)
+
+force_service_checks()
+force_service_checks()
+
+print 'Done, all service checks should be up to date.'


### PR DESCRIPTION
Adds 2 helper scripts that can be used during dev or on CI to check the status of nagios.

**host-svc-check**

Schedules a check of all services for the currently configured host (RHMAP_ROUTER_DNS). Takes into account that the CPU check potentially requires 2 runs before it will be OK. 

Test inside container:

```
[vagrant@ose32 ~]$ oc rsh nagios-2-6i3wq 
sh-4.2$ /opt/rhmap/host-svc-check 
Forcing service checks on 'localhost' ...
Waiting 20s ...
Forcing service checks on 'localhost' ...
Waiting 20s ...
Done, all service checks should be up to date.
```

**check-status**

Get the service status of the currently configured host (RHMAP_ROUTER_DNS). Returns a non zero exit status if any of the service checks are not OK, or there are no service checks for the host. Makes use of the jsonquery endpoints that are available in the newer version of nagios https://nagios-mbaas.local.feedhenry.io/nagios/jsonquery.html. 

Test inside container:

```
[vagrant@ose32 ~]$ oc rsh nagios-2-6i3wq 
sh-4.2$ /opt/rhmap/check-status 
Service Check: Container::CPU Usage, Status Code: 2
Service Check: fh-metrics::Ping, Status Code: 2
Service Check: ups::Ping, Status Code: 2
Service Check: fh-messaging::Ping, Status Code: 2
Service Check: mysql::health, Status Code: 2
Service Check: fh-appstore::Ping, Status Code: 2
Service Check: Container::Resource Limits, Status Code: 2
Service Check: fh-scm::Ping, Status Code: 2
Service Check: redis:ping, Status Code: 2
Service Check: fh-messaging::Health, Status Code: 2
Service Check: millicore::Health, Status Code: 2
Service Check: Storage::Pod::Disk Usage, Status Code: 2
Service Check: fh-metrics::Health, Status Code: 2
Service Check: Container::Memory Usage, Status Code: 2
Service Check: fh-ngui::Health, Status Code: 2
Service Check: fh-supercore::Ping, Status Code: 2
Service Check: fh-aaa::Health, Status Code: 2
Service Check: fh-supercore::Health, Status Code: 2
Service Check: keycloak:Health, Status Code: 2
Service Check: fh-scm::Health, Status Code: 2
Service Check: fh-ngui::Ping, Status Code: 2
Service Check: mongodb-1:Ping, Status Code: 2
Service Check: fh-aaa::Ping, Status Code: 2
Service Check: millicore::Ping, Status Code: 2
Service Check: fh-appstore::Health, Status Code: 2
Service Check: ups::Health, Status Code: 2
Service Check: memcached:ping, Status Code: 2
sh-4.2$ echo $?
0
```

