### PR TITLE
added support to find status value from myState or state before treat…

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -175,7 +175,7 @@ define service {
 
 define service {
        service_description mongodb::replicaset
-       check_command check_mongodb!mongodb,mongodb-service,mongodb-1
+       check_command check_mongodb!mongodb,mongodb-service
        use generic-service
        hostgroup_name mbaas
        notes The mongodb replica set may not be functioning properly.  There should be one and only one primary member and zero or more secondary members

--- a/plugins/default/lib/mongodb_health.py
+++ b/plugins/default/lib/mongodb_health.py
@@ -51,7 +51,7 @@ check_mongodb_cmd = (
 def parse_mongo_result(output):
     try:
         js = json.loads(output)
-        return int(js["myState"])
+        return int(js.get("myState", js.get("state")))
     except:
         return None
 

--- a/plugins/default/lib/test_mongodb_health.py
+++ b/plugins/default/lib/test_mongodb_health.py
@@ -42,6 +42,11 @@ class TestParseMongoResult(unittest.TestCase):
             '7","health":1,"state":2,"stateStr":"SECONDARY","uptime":93162,"optime":{"t":1470269408'
             ',"i":2},"optimeDate":"2016-08-04T00:10:08.000Z","self":true}],"ok":1}'
         ), REPLSET_STATUS.SECONDARY)
+        self.assertEqual(parse_mongo_result(
+            '{"state":10,"stateStr":"REMOVED","uptime":80472,"optime":{"ts":{"t":1474915670,"i":2},'
+            '"t":{"floatApprox":4}},"optimeDate":"2016-09-26T18:47:50.000Z","ok":0,"errmsg":"Our re'
+            'plica set config is invalid or we are not a member of it","code":93}'
+        ), REPLSET_STATUS.REMOVED)
         self.assertEqual(parse_mongo_result("\n"), None)
         self.assertEqual(parse_mongo_result(""), None)
 


### PR DESCRIPTION
…ing as unknown

[https://issues.jboss.org/browse/RHMAP-10547]

A mongo node in REMOVED status returns a completely different format object than what the mongodb docs say it should ([https://docs.mongodb.com/manual/reference/command/replSetGetStatus/#rs-status-output]).  Instead of getting the node's state from myState, its called state instead.  The logic now looks for a myState first (since this is what mongo documents it should use), then state (if possible), and only resorting to returning None if neither of those produced a usable value.  This should hopefully cover any other states which don't follow the documented output format.
