### PR TITLE
usage of MONGODB_ENDPOINT_COUNT in template

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -173,6 +173,7 @@ define service {
        contact_groups rhmapadmins
 }
 
+{%if mongodb_instances > 1 %}
 define service {
        service_description mongodb::replicaset
        check_command check_mongodb!mongodb,mongodb-service
@@ -181,6 +182,7 @@ define service {
        notes The mongodb replica set may not be functioning properly.  There should be one and only one primary member and zero or more secondary members
        contact_groups rhmapadmins
 }
+{% endif %}
 
 {% for mongodb_service in mongodb_services %}
 define service {
@@ -196,8 +198,8 @@ define service {
 define service {
        service_description mysql::health
        check_command check_mysql!mysql!mysql
-       use generic-service
        hostgroup_name core
+       use generic-service
        notes The mysql instance may not be functioning properly.
        contact_groups rhmapadmins
 }

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -25,11 +25,15 @@ rhmap_router_dns = os.getenv('RHMAP_ROUTER_DNS', 'localhost')
 rhmap_hostgroups = os.getenv('RHMAP_HOSTGROUPS', 'core')
 
 if rhmap_hostgroups == 'mbaas':
-    mongodb_count = int(os.getenv("MONGODB_ENDPOINT_COUNT", 3))
+    try:
+        mongodb_count = int(os.getenv('MONGODB_ENDPOINT_COUNT', 3))
+    #if env var is an empty string or is not able to be converted into a number
+    except ValueError:
+        mongodb_count = 3
 else:
     mongodb_count = 1
 
-mongodb_services = [('mongodb-' + str(i)) for i in range(1, (mongodb_count + 1))]
+mongodb_services = ['mongodb-%s' % i for i in xrange(1, mongodb_count + 1)]
 
 template_file = '/opt/rhmap/fhservices.cfg.j2'
 nagios_config_filename = '/etc/nagios/conf.d/fhservices.cfg'
@@ -42,6 +46,7 @@ j2template = j2env.get_template(template_basename)
 
 j2renderedouput = j2template.render(fh_services=fh_services,
                                     mongodb_services=mongodb_services,
+                                    mongodb_instances=mongodb_count,
                                     rhmap_hostgroups=rhmap_hostgroups,
                                     rhmap_router_dns=rhmap_router_dns,
                                     rhmap_admin_email=rhmap_admin_email)


### PR DESCRIPTION
Uses "MONGODB_ENDPOINT_COUNT" env var in jinja template to include or not replica set monitor (default value is 3).

This wat env var can be set from openshift template param.