### PR TITLE
Created no check-dummy command to deal with localhost down due to pin…

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -1,3 +1,9 @@
+# cannot ping localhost, so force check_dummy=0
+define command{
+    command_name    no-localhost-check
+    command_line    /usr/lib64/nagios/plugins/check_dummy 0 "localhost host check is not checkable"
+}
+
 # Check that a component responds to a /sys/info/ping over HTTP
 define command {
        command_name   check_fh_component_http_ping
@@ -132,8 +138,8 @@ define host {
   check_interval          5
   retry_interval          1
   max_check_attempts      10
-  check_command           check_nagios_host_alive
-  notification_period     workhours
+  check_command           no-localhost-check
+  notification_period     24x7
   notification_interval   120
   notification_options    d,u,r
   contact_groups          rhmapadmins


### PR DESCRIPTION
…g problem.

@pmccarthy I have introduced a small change here to effectively 'disable' host checking for `localhost` due to the fact that ping does not work inside containers, nor is it necessary because if the container is down then nagios wouldn't be working anyway.

Having a "host down" status has other roll-on effects in nagios such as disabling service checks on that host.

Could you please review my change?