### PR TITLE
Adding new plugin for pod affinity validation

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -113,6 +113,11 @@ define command {
   command_line   /opt/rhmap/nagios/plugins/mysql-master-slave-health --service $ARG1$ --containers $ARG2$
 }
 
+define command {
+  command_name   check_pod_affinity
+  command_line   /opt/rhmap/nagios/plugins/pod-affinity
+}
+
 define contact {
        contact_name   rhmapadmin
        use            generic-contact
@@ -241,6 +246,15 @@ define service {
        contact_groups rhmapadmins
 }
 {% endif %}
+
+define service {
+       service_description pod::affinity
+       check_command check_pod_affinity
+       use generic-service
+       hostgroup_name core,mbaas
+       notes This check ensures that each component pod is running on a seperate node
+       contact_groups rhmapadmins
+}
 
 define service {
        service_description jenkins::ping

--- a/plugins/default/lib/openshift.py
+++ b/plugins/default/lib/openshift.py
@@ -7,7 +7,8 @@ def oc(*args):
 
 
 def _get_service_selectors(oc, project, service):
-    svc = json.loads(oc("-n", project, "get", "service", service, "-o", "json"))
+    svc = json.loads(
+        oc("-n", project, "get", "service", service, "-o", "json"))
     return [k + "=" + v for k, v in svc["spec"]["selector"].items()]
 
 
@@ -34,7 +35,8 @@ def _get_running_pod_names(oc, project, selector=None, container_names=None):
     pods = json.loads(oc(*args))["items"]
 
     if container_names:
-        pods = [p for p in pods for c in p["spec"]["containers"] if c["name"] in container_names]
+        pods = [p for p in pods for c in p["spec"]
+                ["containers"] if c["name"] in container_names]
 
     return [p["metadata"]["name"] for p in pods if p["status"]["phase"] == "Running"]
 
@@ -46,12 +48,21 @@ def get_running_pod_names(project, selector=None, container_names=None):
 def _get_nodes_from_names(pods):
     nodes = []
     for pod in pods:
-        nodes.append(json.loads(oc("get", "pods", pod, "-o", "json"))["spec"]["nodeName"])
+        nodes.append(json.loads(
+            oc("get", "pods", pod, "-o", "json"))["spec"]["nodeName"])
     return nodes
 
 
 def get_nodes_from_names(pods):
     return _get_nodes_from_names(pods)
+
+
+def _get_deploymentconfigs(oc, project):
+    return json.loads(oc("-n", project, "get", "dc", "-o", "json"))
+
+
+def get_deploymentconfigs(project):
+    return _get_deploymentconfigs(oc, project)
 
 
 def _exec_in_pods(oc, project, pods, cmd):

--- a/plugins/default/lib/pod_affinity.py
+++ b/plugins/default/lib/pod_affinity.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+############################################################################################
+#
+# Nagios plugin to validate pods are running on separate nodes
+#
+# If 2 pods from the same component are running on the same node, return a warning message
+#
+# Copyright (c) 2018, Red Hat Ltd. All rights reserved.
+#
+############################################################################################
+import sys
+import traceback
+
+import nagios
+import openshift
+
+
+def report(issues):
+    if not issues:
+        print("OK: Component pod distribution as expected")
+        nag_status = nagios.OK
+    else:
+        for issue in issues:
+            print(issue)
+        nag_status = nagios.WARN
+    return nag_status
+
+
+def check():
+    issues = []
+    project = openshift.get_project()
+    deploymentConfigs = openshift.get_deploymentconfigs(project)
+    for deploymentConfig in deploymentConfigs["items"]:
+        componentName = deploymentConfig["metadata"]["name"]
+        pods = openshift.get_running_pod_names(
+            project, container_names=componentName)
+        nodes = openshift.get_nodes_from_names(pods)
+        if len(pods) > 1:
+            for node in set(nodes):
+                nodeCount = nodes.count(node)
+                if nodeCount > 1:
+                    issues.append("WARN: %s has %s pods running on the same node: %s" % (
+                        componentName, nodeCount, node))
+    return report(issues)
+
+
+if __name__ == "__main__":
+    code = nagios.UNKNOWN
+    try:
+        code = check()
+    except:
+        traceback.print_exc()
+    finally:
+        sys.exit(code)

--- a/plugins/default/pod-affinity
+++ b/plugins/default/pod-affinity
@@ -1,0 +1,1 @@
+lib/pod_affinity.py


### PR DESCRIPTION
**Summary**
In a HA Openshift environment a component with multiple identical pods should have these pods running on separate nodes. This check will issue a warning message should it find two identical pods running on the same node. It is then up to the cluster administrator to determine whether or not these pods should be moved/re-scheduled.

**Validation**
Scale a component to a minimum of 2 pods on the same Openshift node. The expected outcome of the check should be similar to the below example:
```
WARN: redis has 2 pods running on the same node: <node-name>
```
Now schedule these 2 pods to run on separate Openshift nodes. The expected outcome should be:
```
OK: Component pod distribution as expected
```