### PR TITLE
fix(Nagios Alert): Ignore /etc/hosts to create disk usage alerts

### DIFF
--- a/plugins/default/lib/disk_usage.py
+++ b/plugins/default/lib/disk_usage.py
@@ -38,8 +38,7 @@ check_disk_cmd = ("df", "--output=pcent,ipcent,target")
 # Example output:
 # Use% IUse% Mounted on
 #   1%    1% /
-#  20%    8% /etc/hosts
-check_disk_output_pattern = re.compile(r"\s*(\d+)%\s+(\d+)%\s+(.+)$")
+check_disk_output_pattern = re.compile(r"\s*(\d+)%\s+(\d+)%\s+(?!\/etc\/hosts)(.+)$")
 
 
 def parse_df_line(line):

--- a/plugins/default/lib/test_disk_usage.py
+++ b/plugins/default/lib/test_disk_usage.py
@@ -39,9 +39,6 @@ class TestParseDfLine(unittest.TestCase):
             r"  1%    1% /"),
             ("/", 1, 1))
         self.assertEqual(parse_df_line(
-            r" 10%    1% /etc/hosts"),
-            ("/etc/hosts", 10, 1))
-        self.assertEqual(parse_df_line(
             r"  1%    1% /run/secrets/kubernetes.io/serviceaccount"),
             ("/run/secrets/kubernetes.io/serviceaccount", 1, 1))
         self.assertEqual(parse_df_line(
@@ -55,9 +52,8 @@ class TestParseDfLines(unittest.TestCase):
         self.assertEqual(parse_df_lines(
             "Use% IUse% Mounted on\n"
             "  1%    1% /\n"
-            " 19%    8% /etc/hosts\n"
             "  1%    1% /run/secrets/kubernetes.io/serviceaccount\n"),
-            [("/", 1, 1), ("/etc/hosts", 19, 8), ("/run/secrets/kubernetes.io/serviceaccount", 1, 1)])
+            [("/", 1, 1), ("/run/secrets/kubernetes.io/serviceaccount", 1, 1)])
 
 
 class TestReport(unittest.TestCase):


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-17437

## What
Don't count the `/etc/hosts` to create disk usage alerts in the Nagios

## Why
Shown Nagios alerts about disk usage when they should not occur. 

## How
Remove the host disk usage for it won't have any effect on the Nagios check result.

## Verification Steps
1. Go to the OCP console and deploy Nagios (4.0.8-293c5a5) for rhmap-core project
2. Go to the Nagios and check the report usage of disk usage on it. 
Following an example with the `/etc/hosts` checked for a component. After this PR the `etc/host` check cannot so long be there.
 
```
OK: fh-messaging-1-l22wq:fh-messaging:/ - bytes used: 72%, inodes used: 8%
OK: fh-messaging-1-l22wq:fh-messaging:/etc/hosts - bytes used: 72%, inodes used: 8%
```

<img width="524" alt="screen shot 2018-08-10 at 12 02 39" src="https://user-images.githubusercontent.com/7708031/43954679-4fb9d6e0-9c95-11e8-8838-ac27ec24960c.png">

Following the test performed. 

<img width="725" alt="screen shot 2018-08-10 at 14 34 37" src="https://user-images.githubusercontent.com/7708031/43960657-9ac86d80-9caa-11e8-8555-5c5c75540363.png">

It can be checked in [nagios-rhmap-core.csteam2.skunkhenry.com](https://nagios-rhmap-core.csteam2.skunkhenry.com/)
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [] Finished task
- [x] TODO

## Additional Notes

 

