### PR TITLE
👽 Remove --show-all for oc 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yum install -y epel-release && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    curl --retry 999 --retry-max-time 0 -sSL https://github.com/openshift/origin/releases/download/v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-linux-64bit.tar.gz | tar xzv && \
+    curl --retry 999 --retry-max-time 0 -sSL https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz | tar xzv && \
     mv openshift-origin-*/* /usr/bin/ && \
     mkdir /.kube && \
     mkdir -p /opt/rhmap/ && \

--- a/plugins/default/lib/openshift.py
+++ b/plugins/default/lib/openshift.py
@@ -90,8 +90,7 @@ def exec_in_pod_container(project, pod, container, cmd):
 
 
 def _get_running_pod_containers(oc, project, selector=None, container_names=None):
-    # Changed param from "--show-all=false" to "--show-all=true" due to changes in oc client
-    args = ("-n", project, "get", "pods", "--show-all=true", "-o", "json")
+    args = ("-n", project, "get", "pods", "-o", "json")
 
     if selector:
         args += ("--selector=" + ",".join(selector),)


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-21670

In `oc` 3.10, if the `--show-all` parameter is used for `oc get`, then a deprecation warning is output along with the regular output. When this python script tries to decode the whole output to JSON, it fails (even though the regular output without the warning is valid and decode-able).

Given that this parameter appears to have been arbitrarily changed from `--show-all=false` to `--show-all=true` in [1] just to get around some other issue with a different `oc` version, I think it's fine to just remove it.

[1] https://github.com/feedhenry/nagios-container/pull/48