### PR TITLE
Rhmap 21696 mysql check fix

### DIFF
--- a/fhservices.cfg.j2
+++ b/fhservices.cfg.j2
@@ -338,6 +338,18 @@ define service {
 }
 {% endfor %}
 
+{% if mysql_services|length == 1 %}
+define service {
+  service_description mysql::health
+  check_command check_mysql!mysql!mysql
+  hostgroup_name core
+  use generic-service
+  notes The mysql instance may not be functioning properly.
+  contact_groups rhmapadmins
+}
+{% endif %}
+
+{% if mysql_services|length > 1 %}
 {% for mysql_service in mysql_services %}
 define service {
   service_description {{ mysql_service }}::health
@@ -348,6 +360,7 @@ define service {
   contact_groups rhmapadmins
 }
 {% endfor %}
+{% endif %}
 
 define service {
        service_description Container::Memory Usage

--- a/make-nagios-fhservices-cfg
+++ b/make-nagios-fhservices-cfg
@@ -45,10 +45,10 @@ userdata_mongodb_services = ['mongodb-%s' % i for i in xrange(1, userdata_mongod
 
 
 try:
-    mysql_count = int(os.getenv('MYSQL_ENDPOINT_COUNT', 3))
+    mysql_count = int(os.getenv('MYSQL_ENDPOINT_COUNT', 1))
 #if env var is an empty string or is not able to be converted into a number
 except ValueError:
-    mysql_count = 3
+    mysql_count = 1
 
 mysql_services = ['mysql'] + ['mysql-%s' % i for i in xrange(2, mysql_count + 1)]
 


### PR DESCRIPTION
Fixes mysql checks for SM deployments.

Verification:

* Deploy the generated container image against a SM RHMAP instance - only one mysql check should be listed
* rsh into the nagios pod and check the services file: /etc/nagios/conf.d/fhservices.cfg (only one mysql service check should be defined there)
